### PR TITLE
Avoid possible indefinite postposition of tasks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export class Queue {
     }).then(() => {
       this.workers.push(worker);
       if (this.tasks.length > 0) {
-        this.schedule(this.tasks.pop());
+        this.schedule(this.tasks.shift());
       } else if (this.isEmpty() && this.emptyCallback) {
         this.emptyCallback();
       }


### PR DESCRIPTION
Take the next task from the beginning of the array to avoid possible indefinite postposition if queued a long running task 